### PR TITLE
Chrome addon: trusty **or later**

### DIFF
--- a/user/chrome.md
+++ b/user/chrome.md
@@ -4,7 +4,9 @@ layout: en
 
 ---
 
-The Google Chrome addon allows Travis CI builds to install Google Chrome at run time. To use the addon you need to be running builds on either the [Trusty build environment](/user/reference/trusty/) or the [macOS build environment](/user/reference/osx/).
+The Google Chrome addon allows Travis CI builds to install Google Chrome at run time.
+
+This addon supports both the Linux and [macOS](/user/reference/osx/) [build environment](https://docs.travis-ci.com/user/reference/overview/). For Linux, you must be running on [Ubuntu Trusty 14.04](https://docs.travis-ci.com/user/reference/trusty/) or later build environments.
 
 ## Selecting a Chrome version
 


### PR DESCRIPTION
The original commit that introduced this documentation (https://github.com/travis-ci/docs-travis-ci-com/commit/61db796d80badaa3338010dd8972a1ac18b1696a) had the wording "Trusty **or later**" which got lost in #1136. As far as I can tell it was not an explicit decision to imply that Xenial 16.04 or Bionic 18.04 does not work with the addon.

Unfortunately, a lot of us (including myself) just took it for granted that the documentation was correct and assumed the addon somehow *requires* Trusty. This information propagated into a lot of external documentation since then, including the official puppeteer [documentation][1], blog posts hosted on [developers.google.com][2], personal blogs, StackOverflow etc.

[1]: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-on-travis-ci
[2]: https://developers.google.com/web/updates/2017/06/headless-karma-mocha-chai

Today, Chromium 77 was released. Something has changed in the pre-built binary such that they no longer unpack/install successfully on Trusty.

From https://travis-ci.org/ember-learn/super-rentals-tutorial/builds/583327911:

```
$ export CHROME_SOURCE_URL=https://dl.google.com/dl/linux/direct/google-chrome-stable_current_amd64.deb
Installing Google Chrome stable
$ wget --no-verbose -O /tmp/$(basename $CHROME_SOURCE_URL) $CHROME_SOURCE_URL
2019-09-10 21:21:43 URL:https://dl.google.com/dl/linux/direct/google-chrome-stable_current_amd64.deb [62302944/62302944] -> "/tmp/google-chrome-stable_current_amd64.deb" [1]
dpkg-deb: error: archive '/tmp/google-chrome-stable_current_amd64.deb' has premature member 'control.tar.xz' before 'control.tar.gz', giving up
dpkg: error processing archive /tmp/google-chrome-stable_current_amd64.deb (--install):
 subprocess dpkg-deb --control returned error exit status 2
Errors were encountered while processing:
 /tmp/google-chrome-stable_current_amd64.deb
```

It seems like `control.tar.gz` changed to `control.tar.xz` in this release and the `dpkg` version installed on the Travis Trusty environment does not like it. StackOverflow seems to suggest that this is a fixable problem by updating `dpkg` and clearing apt cache, etc. However, after digging into this more, it turns out I have no reason to be running my builds on such an old OS to begin with, and addon worked just fine on Xenial (probably Bionic too).

From https://travis-ci.org/ember-learn/super-rentals-tutorial/builds/583456917

```
$ export CHROME_SOURCE_URL=https://dl.google.com/dl/linux/direct/google-chrome-stable_current_amd64.deb
Installing Google Chrome stable
$ wget --no-verbose -O /tmp/$(basename $CHROME_SOURCE_URL) $CHROME_SOURCE_URL
2019-09-11 02:45:38 URL:https://dl.google.com/dl/linux/direct/google-chrome-stable_current_amd64.deb [62302944/62302944] -> "/tmp/google-chrome-stable_current_amd64.deb" [1]
Selecting previously unselected package google-chrome-stable.
(Reading database ... 117296 files and directories currently installed.)
Preparing to unpack .../google-chrome-stable_current_amd64.deb ...
Unpacking google-chrome-stable (77.0.3865.75-1) ...
Setting up google-chrome-stable (77.0.3865.75-1) ...
update-alternatives: using /usr/bin/google-chrome-stable to provide /usr/bin/x-www-browser (x-www-browser) in auto mode
update-alternatives: using /usr/bin/google-chrome-stable to provide /usr/bin/gnome-www-browser (gnome-www-browser) in auto mode
update-alternatives: using /usr/bin/google-chrome-stable to provide /usr/bin/google-chrome (google-chrome) in auto mode
Processing triggers for mime-support (3.59ubuntu1) ...
Processing triggers for man-db (2.7.5-1) ...
```

I didn't look into the original issue: what broke the addon in Trusty in the first place, and whether it's something users need to fix on their end or something Travis need to fix (more likely). Given that it doesn't actually work out-of-the-box at the moment, I'm not sure if we should still document Trusty as a supported environment for this addon, but at minimum, we should bring back the "or later" wording.